### PR TITLE
Use java_import_external in bazel-common

### DIFF
--- a/third_party/java/asm/BUILD
+++ b/third_party/java/asm/BUILD
@@ -12,21 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# BUILD rules for https://github.com/google/error-prone. Note that Bazel already
-# applies the Error Prone compiler to all java compilations - this package exports
-# dependencies for Error Prone's libraries
+# BUILD rules for http://asm.ow2.org/
 
-licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
+licenses(["notice"])  # BSD
 
 package(default_visibility = ["//visibility:public"])
 
 java_library(
-    name = "annotations",
-    tags = ["maven:compile_only"],
-    exports = ["@com_google_errorprone_error_prone_annotations//jar"],
-)
-
-java_library(
-    name = "error_prone_javac",
-    exports = ["@com_google_errorprone_javac_shaded//jar"],
+    name = "asm",
+    exports = ["@org_ow2_asm_asm//jar"],
 )

--- a/workspace_defs.bzl
+++ b/workspace_defs.bzl
@@ -13,6 +13,31 @@
 # limitations under the License.
 """A WORKSPACE macro for Google open-source libraries to use"""
 
+load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
+
+_MAVEN_MIRRORS = [
+    "http://bazel-mirror.storage.googleapis.com/repo1.maven.org/maven2/",
+    "http://repo1.maven.org/maven2/",
+    "http://maven.ibiblio.org/maven2/",
+]
+
+def _maven_import(artifact, sha256, licenses, **kwargs):
+  parts = artifact.split(":")
+  group_id = parts[0]
+  artifact_id = parts[1]
+  version = parts[2]
+  name = ("%s_%s" %(group_id, artifact_id)).replace(".", "_").replace("-", "_")
+  url_suffix = "{0}/{1}/{2}/{1}-{2}.jar".format(group_id.replace(".", "/"), artifact_id, version)
+
+  java_import_external(
+      name = name,
+      jar_urls = [base + url_suffix for base in _MAVEN_MIRRORS],
+      jar_sha256 = sha256,
+      licenses = licenses,
+      tags = [artifact],
+      **kwargs
+  )
+
 def google_common_workspace_rules():
   """Defines WORKSPACE rules for Google open-source libraries.
 
@@ -27,172 +52,172 @@ def google_common_workspace_rules():
       build_tools_version = "26.0.2",
   )
 
-  native.maven_jar(
-      name = "javax_annotation_jsr250_api",
+  _maven_import(
       artifact = "javax.annotation:jsr250-api:1.0",
-      sha1 = "5025422767732a1ab45d93abfea846513d742dcf",
+      sha256 = "a1a922d0d9b6d183ed3800dfac01d1e1eb159f0e8c6f94736931c1def54a941f",
+      licenses = ["notice"],
   )
 
-  native.maven_jar(
-      name = "com_google_code_findbugs_jsr305",
+  _maven_import(
       artifact = "com.google.code.findbugs:jsr305:3.0.1",
-      sha1 = "f7be08ec23c21485b9b5a1cf1654c2ec8c58168d",
+      sha256 = "c885ce34249682bc0236b4a7d56efcc12048e6135a5baf7a9cde8ad8cda13fcd",
+      licenses = ["notice"],
   )
 
-  native.maven_jar(
-      name = "javax_inject_javax_inject",
+  _maven_import(
       artifact = "javax.inject:javax.inject:1",
-      sha1 = "6975da39a7040257bd51d21a231b76c915872d38",
+      sha256 = "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
+      licenses = ["notice"],
   )
 
-  native.maven_jar(
-      name = "javax_inject_javax_inject_tck",
+  _maven_import(
       artifact = "javax.inject:javax.inject-tck:1",
-      sha1 = "bb0090d50219c265be40fcc8e034dae37fa7be99",
+      sha256 = "4a8058994e3c9ef8711f8aebef1276ff46f751fdd81cebd718a327fbaa19470c",
+      licenses = ["notice"],
   )
 
-  native.maven_jar(
-      name = "com_google_guava_guava",
+  _maven_import(
       artifact = "com.google.guava:guava:24.0-jre",
-      sha1 = "041ac1e74d6b4e1ea1f027139cffeb536c732a81",
+      licenses = ["notice"],
+      sha256 = "e0274470b16ba1154e926b5f54ef8ae159197fbc356406bda9b261ba67e3e599",
   )
 
-  native.maven_jar(
-      name = "com_google_guava_guava_testlib",
+  _maven_import(
       artifact = "com.google.guava:guava-testlib:24.0-jre",
-      sha1 = "8c960e7ce5d3dd662b456c6d567ee0417512c6c3",
+      sha256 = "6d9c75917b8c4e815c7b23071dd146ff23f310bef05683eef5cbc675d6cfc317",
+      licenses = ["notice"],
   )
 
-  native.maven_jar(
-      name = "com_google_errorprone_javac",
+  _maven_import(
       artifact = "com.google.errorprone:javac-shaded:9-dev-r4023-3",
-      sha1 = "72b688efd290280a0afde5f9892b0fde6f362d1d",
+      sha256 = "65bfccf60986c47fbc17c9ebab0be626afc41741e0a6ec7109e0768817a36f30",
+      licenses = ["notice"],
   )
 
-  native.maven_jar(
-      name = "com_google_googlejavaformat_google_java_format",
+  _maven_import(
       artifact = "com.google.googlejavaformat:google-java-format:1.5",
-      sha1 = "fba7f130d29061d2d2ea384b4880c10cae92ef73",
+      sha256 = "aa19ad7850fb85178aa22f2fddb163b84d6ce4d0035872f30d4408195ca1144e",
+      licenses = ["notice"],
   )
 
-  native.maven_jar(
-      name = "com_google_auto_auto_common",
+  _maven_import(
       artifact = "com.google.auto:auto-common:0.10",
-      sha1 = "c8f153ebe04a17183480ab4016098055fb474364",
+      sha256 = "b876b5fddaceeba7d359667f6c4fb8c6f8658da1ab902ffb79ec9a415deede5f",
+      licenses = ["notice"],
   )
 
-  native.maven_jar(
-      name = "com_google_auto_factory_auto_factory",
+  _maven_import(
       artifact = "com.google.auto.factory:auto-factory:1.0-beta5",
-      sha1 = "78b93b2334d0e2fb0d65c00127d4dcce261a83fc",
+      sha256 = "e6bed6aaa879f568449d735561a6a26a5a06f7662ed96ca88d27d2200a8dc6cf",
+      licenses = ["notice"],
   )
 
-  native.maven_jar(
-      name = "com_google_auto_service_auto_service",
+  _maven_import(
       artifact = "com.google.auto.service:auto-service:1.0-rc4",
-      sha1 = "44954d465f3b9065388bbd2fc08a3eb8fd07917c",
+      sha256 = "e422d49c312fd2031222e7306e8108c1b4118eb9c049f1b51eca280bed87e924",
+      licenses = ["notice"],
   )
 
-  native.maven_jar(
-      name = "com_google_auto_value_auto_value",
+  _maven_import(
       artifact = "com.google.auto.value:auto-value:1.5.3",
-      sha1 = "514df6a7c7938de35c7f68dc8b8f22df86037f38",
+      sha256 = "238d3b7535096d782d08576d1e42f79480713ff0794f511ff2cc147363ec072d",
+      licenses = ["notice"],
   )
 
-  native.maven_jar(
-      name = "com_google_errorprone_error_prone_annotations",
+  _maven_import(
       artifact = "com.google.errorprone:error_prone_annotations:2.2.0",
-      sha1 = "88e3c593e9b3586e1c6177f89267da6fc6986f0c",
+      sha256 = "6ebd22ca1b9d8ec06d41de8d64e0596981d9607b42035f9ed374f9de271a481a",
+      licenses = ["notice"],
   )
 
-  native.maven_jar(
-      name = "junit_junit",
+  _maven_import(
       artifact = "junit:junit:4.11",
-      sha1 = "4e031bb61df09069aeb2bffb4019e7a5034a4ee0",
+      sha256 = "90a8e1603eeca48e7e879f3afbc9560715322985f39a274f6f6070b43f9d06fe",
+      licenses = ["notice"],
   )
 
-  native.maven_jar(
-      name = "com_google_testing_compile_compile_testing",
+  _maven_import(
       artifact = "com.google.testing.compile:compile-testing:0.15",
-      sha1 = "d6619b8484ee928fdd7520c0aa6d1c1ffb1d781b",
+      sha256 = "f741c21d44ddf4580e99cfc537e76d1760d864637aec1e21d5341f672a165d4c",
+      licenses = ["notice"],
   )
 
-  native.maven_jar(
-      name = "org_mockito_mockito_core",
+  _maven_import(
       artifact = "org.mockito:mockito-core:1.9.5",
-      sha1 = "c3264abeea62c4d2f367e21484fbb40c7e256393",
+      sha256 = "f97483ba0944b9fa133aa29638764ddbeadb51ec3dbc02074c58fa2caecd07fa",
+      licenses = ["notice"],
   )
 
-  native.maven_jar(
-      name = "org_hamcrest_hamcrest_core",
+  _maven_import(
       artifact = "org.hamcrest:hamcrest-core:1.3",
-      sha1 = "42a25dc3219429f0e5d060061f71acb49bf010a0",
+      sha256 = "66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9",
+      licenses = ["notice"],
   )
 
-  native.maven_jar(
-      name = "org_objenesis_objenesis",
+  _maven_import(
       artifact = "org.objenesis:objenesis:1.0",
-      sha1 = "9b473564e792c2bdf1449da1f0b1b5bff9805704",
+      sha256 = "c5694b55d92527479382f254199b3c6b1d8780f652ad61e9ca59919887f491a8",
+      licenses = ["notice"],
   )
 
-  native.maven_jar(
-      name = "com_google_truth_truth",
+  _maven_import(
       artifact = "com.google.truth:truth:0.39",
-      sha1 = "bd1bf5706ff34eb7ff80fef8b0c4320f112ef899",
+      sha256 = "25ce04464511d4a7c05e1034477900a897228cba2f86110d2ed49c956d9a82af",
+      licenses = ["notice"],
   )
 
-  native.maven_jar(
-      name = "com_google_truth_extensions_truth_java8_extension",
+  _maven_import(
       artifact = "com.google.truth.extensions:truth-java8-extension:0.39",
-      sha1 = "1499bc88cda9d674afb30da9813b44bcd4512d0d",
+      sha256 = "47d3a91a3accbe062fbae59f95cc0e02f0483c60d1340ff82c89bc6ab82fa10a",
+      licenses = ["notice"],
   )
 
-  native.maven_jar(
-      name = "com_squareup_javapoet",
+  _maven_import(
       artifact = "com.squareup:javapoet:1.10.0",
-      sha1 = "712c178d35185d8261295913c9f2a7d6867a6007",
+      sha256 = "20ef4b82e43ff7c652281a21313cf3b941092467add3fa73509c26f6969efdab",
+      licenses = ["notice"],
   )
 
-  native.maven_jar(
-      name = "io_grpc_grpc_core",
+  _maven_import(
       artifact = "io.grpc:grpc-core:1.2.0",
-      sha1 = "f12a213e2b59a0615df2cc9bed35dc15fd2fee37",
+      sha256 = "4434ffd957dc5ca752d8a8e6e71fa6d598a05bb02b4fc08e48e53d878a004ee5",
+      licenses = ["notice"],
   )
 
-  native.maven_jar(
-      name = "io_grpc_grpc_netty",
+  _maven_import(
       artifact = "io.grpc:grpc-netty:1.2.0",
-      sha1 = "e2682d2dc052898f87433e7a6d03d104ef98df74",
+      sha256 = "c9379d17fdec2eae203679495a695b523e01f2541169d28f5b780de298aa17c8",
+      licenses = ["notice"],
   )
 
-  native.maven_jar(
-      name = "io_grpc_grpc_context",
+  _maven_import(
       artifact = "io.grpc:grpc-context:1.2.0",
-      sha1 = "1932db544cbb427bc18f902c7ebbb3f7e44991df",
+      sha256 = "4f1fed2735f011ba6f8ab1faa003ef67bade9e773f5a5ec4b69eb2a124500ca6",
+      licenses = ["notice"],
   )
 
-  native.maven_jar(
-      name = "io_grpc_grpc_protobuf",
+  _maven_import(
       artifact = "io.grpc:grpc-protobuf:1.2.0",
-      sha1 = "2676852d2dbd20155d9b1a940a456eae5b7445f0",
+      sha256 = "19797fc26192dfcc4570ec26c12ba84583842b0ccbcd7d54982f922d33209383",
+      licenses = ["notice"],
   )
 
-  native.maven_jar(
-      name = "io_grpc_grpc_stub",
+  _maven_import(
       artifact = "io.grpc:grpc-stub:1.2.0",
-      sha1 = "964dda53b3085bfd17c7aaf51495f9efc8bda36c",
+      sha256 = "bf3eae95175ed36eee086d5fb320583fc492b144bd733d6e19515c7568ee2e2b",
+      licenses = ["notice"],
   )
 
-  native.maven_jar(
-      name = "io_grpc_grpc_all",
+  _maven_import(
       artifact = "io.grpc:grpc-all:1.2.0",
-      sha1 = "f32006a1245dfa2d68bf92a1b4cc01831889c95b",
+      sha256 = "6b697a05b203216b853394d276c429da243cdf50f519688b33f4edbbf5f126d7",
+      licenses = ["notice"],
   )
 
-  native.maven_jar(
-      name = "com_google_protobuf_protobuf_java",
+  _maven_import(
       artifact = "com.google.protobuf:protobuf-java:3.5.0",
-      sha1 = "200fb936907fbab5e521d148026f6033d4aa539e",
+      sha256 = "49a3c7b3781d4b7b2d15063e125824260c9b46bdb62494b63b367b661fdb2b26",
+      licenses = ["notice"],
   )
 
   native.http_archive(
@@ -209,14 +234,14 @@ def google_common_workspace_rules():
       urls = ["https://github.com/google/protobuf/archive/v3.5.0.zip"],
   )
 
-  native.maven_jar(
-      name = "org_checkerframework_checker_compat_qual",
+  _maven_import(
       artifact = "org.checkerframework:checker-compat-qual:2.3.0",
-      sha1 = "69cb4fea55a9d89b8827d107f17c985cc1a76052",
+      sha256 = "7b2ebd4c746231525a93912fd66055639fc6a8a9dc28392bc1e0ae239011d5fc",
+      licenses = ["notice"],
   )
 
-  native.maven_jar(
-      name = "org_ow2_asm_asm",
+  _maven_import(
       artifact = "org.ow2.asm:asm:6.1",
-      sha1 = "94a0d17ba8eb24833cd54253ace9b053786a9571",
+      sha256 = "db788a985a2359666aa29a9a638f03bb67254e4bd5f453a32717593de887b6b1",
+      licenses = ["notice"],
   )


### PR DESCRIPTION
This gives better reliability by using the Bazel Downloader and providing multiple mirrors. It also (in the next bazel release) will support tags, which will allow for generation of pom files within bazel.

Also:
  - Fix error prone's shaded_javac artifact name to be canonical
  - Actually add the third_party/java/asm BUILD file