### PR TITLE
Moe Sync

### DIFF
--- a/third_party/java/guava/BUILD
+++ b/third_party/java/guava/BUILD
@@ -20,6 +20,7 @@ package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "guava",
+    exported_plugins = [":beta-checker"],
     exports = ["@com_google_guava_guava//jar"],
 )
 
@@ -27,4 +28,10 @@ java_library(
     name = "testlib",
     testonly = 1,
     exports = ["@com_google_guava_guava_testlib//jar"],
+)
+
+java_plugin(
+    name = "beta-checker",
+    visibility = ["//visibility:private"],
+    deps = ["@com_google_guava_guava_beta_checker//jar"],
 )

--- a/workspace_defs.bzl
+++ b/workspace_defs.bzl
@@ -78,13 +78,19 @@ def google_common_workspace_rules():
 
   _maven_import(
       artifact = "com.google.guava:guava:24.0-jre",
-      licenses = ["notice"],
       sha256 = "e0274470b16ba1154e926b5f54ef8ae159197fbc356406bda9b261ba67e3e599",
+      licenses = ["notice"],
   )
 
   _maven_import(
       artifact = "com.google.guava:guava-testlib:24.0-jre",
       sha256 = "6d9c75917b8c4e815c7b23071dd146ff23f310bef05683eef5cbc675d6cfc317",
+      licenses = ["notice"],
+  )
+
+  _maven_import(
+      artifact = "com.google.guava:guava-beta-checker:1.0",
+      sha256 = "9a01eeec0f94553db9464a9b13e072ba6049ab9c3afdd140edef838224bf71f5",
       licenses = ["notice"],
   )
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Use the Guava Beta Checker by default

Users can always decide to add --javacopts=-Xep:BetaApi:OFF in their tools/bazel.rc in their workspace, or @SuppressWarnings. At the moment, however, bazel-common users should all be libraries, so using the Beta Checker is generally a good thing for them to do.

a5b8936217a42bfe59761287a0cf1a0b7568b030