### PR TITLE
Moe Sync

### DIFF
--- a/tools/jarjar/jarjar.bzl
+++ b/tools/jarjar/jarjar.bzl
@@ -77,7 +77,9 @@ def _jarjar_library(ctx):
 jarjar_library = rule(
     attrs = {
         "rules": attr.string_list(),
-        "jars": attr.label_list(),
+        "jars": attr.label_list(
+            allow_files = True, # TODO(ronshapiro): validate that these are jars?
+        ),
         "_java_binary": attr.label(
             default = Label("@local_jdk//:bin/java"),
             allow_single_file = True,


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Allow files in the jarjar_library.jars attribute.

This is most important for using -src.jars, for when we want to union source jars

e86af4308a8045a47b7766411541e7c62c0d25a2