### PR TITLE
Export rule implementations

### DIFF
--- a/tools/maven/pom_file.bzl
+++ b/tools/maven/pom_file.bzl
@@ -174,6 +174,12 @@ def _pom_file(ctx):
         substitutions = substitutions,
     )
 
+exports = struct(
+    MavenInfo = MavenInfo,
+    _collect_maven_info = _collect_maven_info,
+    _pom_file = _pom_file
+)
+
 pom_file = rule(
     attrs = {
         "template_file": attr.label(


### PR DESCRIPTION
We at @graknlabs need to depend on `pom_file` implementation in our own rule -- so, modifying the rule in analogy to [`rules_docker`](https://github.com/bazelbuild/rules_docker/blob/master/container/image.bzl#L16-L40)