### PR TITLE
handle both absolute and relative path scenario in jarjar.bzl

### DIFF
--- a/tools/jarjar/jarjar.bzl
+++ b/tools/jarjar/jarjar.bzl
@@ -23,7 +23,7 @@ def _jarjar_library(ctx):
     jar_files = depset(transitive = [jar.files for jar in ctx.attr.jars]).to_list()
 
     command = """
-  JAVA_HOME=$(cd "{java_home}" && pwd -P)
+  JAVA_HOME=$(cd "{java_home}" && pwd -P) # this is used outside of the root
 
   TMPDIR=$(mktemp -d)
   for jar in {jars}; do

--- a/tools/jarjar/jarjar.bzl
+++ b/tools/jarjar/jarjar.bzl
@@ -23,7 +23,7 @@ def _jarjar_library(ctx):
     jar_files = depset(transitive = [jar.files for jar in ctx.attr.jars]).to_list()
 
     command = """
-  JAVA_HOME=$(pwd)/{java_home} # this is used outside of the root
+  JAVA_HOME=$(cd "{java_home}" && pwd -P)
 
   TMPDIR=$(mktemp -d)
   for jar in {jars}; do

--- a/tools/jarjar/jarjar.bzl
+++ b/tools/jarjar/jarjar.bzl
@@ -23,7 +23,7 @@ def _jarjar_library(ctx):
     jar_files = depset(transitive = [jar.files for jar in ctx.attr.jars]).to_list()
 
     command = """
-  JAVA_HOME=$(cd "{java_home}" && pwd -P) # this is used outside of the root
+  JAVA_HOME=$(cd "{java_home}" && pwd) # this is used outside of the root
 
   TMPDIR=$(mktemp -d)
   for jar in {jars}; do


### PR DESCRIPTION
Solves https://github.com/google/bazel-common/issues/43 by using `pwd` inside the directory in order to get the full path to Java

I am not sure if the comment `# this is used outside of the root`, is still relevant given my change. I am open for any suggestion on whether I should keep it.