### PR TITLE
Fix incompatible_no_support_tools_in_action_inputs

### DIFF
--- a/tools/jarjar/jarjar.bzl
+++ b/tools/jarjar/jarjar.bzl
@@ -65,10 +65,10 @@ def _jarjar_library(ctx):
     ctx.actions.run_shell(
         command = command,
         inputs = [
-            ctx.executable._jarjar,
             ctx.outputs._rules_file,
         ] + jar_files + ctx.files._jdk,
         outputs = [ctx.outputs.jar],
+        tools = [ctx.executable._jarjar]
     )
 
 jarjar_library = rule(


### PR DESCRIPTION
Adapting to incompatible change introduced in `bazel 0.15`
From [here](https://blog.bazel.build/2018/06/26/bazel-0.15.html):

>If the --incompatible_no_support_tools_in_action_inputs flag is enabled, Skylark action inputs are no longer scanned for tools. Move any such inputs to the newly introduced 'tools' attribute.