### PR TITLE
Moe Sync

### DIFF
--- a/tools/jarjar/jarjar.bzl
+++ b/tools/jarjar/jarjar.bzl
@@ -64,11 +64,9 @@ def _jarjar_library(ctx):
 
     ctx.actions.run_shell(
         command = command,
-        inputs = [
-            ctx.executable._jarjar,
-            ctx.outputs._rules_file,
-        ] + jar_files + ctx.files._jdk,
+        inputs = [ctx.outputs._rules_file] + jar_files + ctx.files._jdk,
         outputs = [ctx.outputs.jar],
+        tools = [ctx.executable._jarjar],
     )
 
 jarjar_library = rule(


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix incompatible_no_support_tools_in_action_inputs error

Closes https://github.com/google/bazel-common/pull/45

870db055e0753f73e0d8390c2db2a80acec0aa33