### PR TITLE
Moe Sync

### DIFF
--- a/tools/jarjar/jarjar.bzl
+++ b/tools/jarjar/jarjar.bzl
@@ -23,7 +23,7 @@ def _jarjar_library(ctx):
     jar_files = depset(transitive = [jar.files for jar in ctx.attr.jars]).to_list()
 
     command = """
-  JAVA_HOME=$(pwd)/{java_home} # this is used outside of the root
+  JAVA_HOME="$(cd "{java_home}" && pwd)" # this is used outside of the root
 
   TMPDIR=$(mktemp -d)
   for jar in {jars}; do


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Handle both absolute and relative path scenario in jarjar.bzl

Closes https://github.com/google/bazel-common/issue/43 by using pwd inside the directory in order to get the full path to Java
Closes https://github.com/google/bazel-common/pull/44

373085755f19fa9e0b6955d32cc1d6913658f68d