### PR TITLE
Moe Sync

### DIFF
--- a/tools/maven/pom_file.bzl
+++ b/tools/maven/pom_file.bzl
@@ -251,7 +251,7 @@ def _maven_info_test_impl(ctx):
         actual = ctx.attr.target[MavenInfo].maven_dependencies,
         msg = "MavenInfo.maven_dependencies",
     )
-    unittest.end(env)
+    return unittest.end(env)
 
 _maven_info_test = unittest.make(
     _maven_info_test_impl,


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Using unittest.bzl, return unittest.end(env) instead of simply calling it

This keeps users compatible with imminent changes to unittest.bzl, which requires rule implementation functions return the result of unittest.end so that the test action is appropriately registered.

a1e3e3f17a13420e2e8343258c9826d11b3aac4d