### PR TITLE
Moe Sync

### DIFF
--- a/tools/javadoc/javadoc.bzl
+++ b/tools/javadoc/javadoc.bzl
@@ -65,7 +65,7 @@ def _javadoc_library(ctx):
     jar_command = "%s/bin/jar cf %s -C tmp ." % (java_home, ctx.outputs.jar.path)
 
     srcs = depset(transitive = [src.files for src in ctx.attr.srcs]).to_list()
-    ctx.action(
+    ctx.actions.run_shell(
         inputs = srcs + classpath + ctx.files._jdk,
         command = "%s && %s" % (" ".join(javadoc_command), jar_command),
         outputs = [ctx.outputs.jar],


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Fix .bzl files with buildifier

This CL fixes .bzl files to make them compatible with the next versions of Bazel. This is done by running the following command on all the .bzl files:

    buildifier --lint=fix --warnings=attr-non-empty,attr-single-file,ctx-actions,output-group

bcbcd84f324a1e47f91ef7da40322219f6df8d61