### PR TITLE
Moe Sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,45 @@
+language: android
+
+os: linux
+dist: trusty
+sudo: required
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - libstdc++-4.9-dev # https://github.com/nodegit/nodegit/issues/853
+      - gcc-4.8
+      - g++-4.8
+
+android:
+  components:
+    - tools
+    - tools # Duplicated as per https://github.com/travis-ci/travis-ci/issues/6040#issuecomment-219367943
+    - build-tools-26.0.2
+    - android-26
+    - platform-tools
+    - extra-android-m2repository
+
+before_install:
+  - wget https://github.com/bazelbuild/bazel/releases/download/"${BAZEL_VERSION}"/bazel_"${BAZEL_VERSION}"-linux-x86_64.deb
+  - sudo dpkg -i bazel_"${BAZEL_VERSION}"-linux-x86_64.deb
+  - sudo rm -f /etc/mavenrc
+  - wget http://www.us.apache.org/dist/maven/maven-3/3.1.1/binaries/apache-maven-3.1.1-bin.tar.gz
+  - tar -zxf apache-maven-3.1.1-bin.tar.gz
+  - export PATH="$PWD/apache-maven-3.1.1/bin:$PATH"
+  - mkdir travis_bin
+  - ln -s $(which gcc-4.8) travis_bin/gcc
+  - ln -s $(which g++-4.8) travis_bin/g++
+  - export PATH="${PWD}/travis_bin:${PATH}"
+
+script: ./build_test.sh
+
+env:
+  global:
+    - BAZEL_VERSION="0.24.1"
+
+branches:
+  only:
+    - master
+    - /^release.*$/

--- a/build_test.sh
+++ b/build_test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Tests that all libraries in bazel-common can build correctly
+
+libraries=""
+for library in $(bazel query --output=label_kind //... | \
+      grep -v "//tools/maven:" | \
+      grep _library | \
+      awk '{print $3}'); do
+  if [[ -z "${libraries}" ]]; then
+    libraries="        \"${library}\","
+  else
+    printf -v libraries '%s\n        "%s",' "${libraries}" "${library}"
+  fi
+done
+
+readonly DIR=build_test
+
+mkdir "${DIR}"
+
+cat <<BUILD_TEST >> "${DIR}"/BUILD
+java_library(
+    name = "build_test",
+    srcs = ["BuildTest.java"],
+    deps = [
+${libraries}
+    ],
+    testonly = 1,
+)
+BUILD_TEST
+
+echo "class BuildTest {}" > "${DIR}"/BuildTest.java
+
+trap "rm -rf ${DIR}/" EXIT
+
+bazel build //build_test

--- a/third_party/java/auto/BUILD
+++ b/third_party/java/auto/BUILD
@@ -81,6 +81,7 @@ java_plugin(
     deps = [
         ":common",
         ":service",
+        "//third_party/java/google_java_format",
         "//third_party/java/guava",
         "//third_party/java/javapoet",
         "@com_google_auto_factory_auto_factory//jar",


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add a build test to bazel-common to ensure that all of the libraries build correctly

This doesn't ensure that all dependencies are satisfied correctly, but at least it ensures that the build files are properly formatted and sha256s are valid. We've already had a number of CLs that have failed one of these two invariants :-/

Also add a missing dep for the @AutoFactory processor. I guess these do some validation, inasmuch as the AutoFactoryProcessor required FormattingFiler from google-java-format in it's initialization step, which runs on java compilations.

c62d5676b19e7f46e10881572c6b8277d4140606