### PR TITLE
Moe Sync

### DIFF
--- a/testing/test_defs.bzl
+++ b/testing/test_defs.bzl
@@ -122,6 +122,7 @@ def _gen_java_tests(
         javacopts = None,
         lib_javacopts = None,
         test_javacopts = None,
+        runtime_deps = None,
         tags = None):
     test_files = []
     supporting_lib_files = []
@@ -162,4 +163,5 @@ def _gen_java_tests(
             tags = _concat(["gen_java_tests"], tags),
             test_class = test_class,
             deps = test_deps,
+            runtime_deps = runtime_deps,
         )

--- a/tools/javadoc/javadoc.bzl
+++ b/tools/javadoc/javadoc.bzl
@@ -73,7 +73,10 @@ def _javadoc_library(ctx):
 
 javadoc_library = rule(
     attrs = {
-        "srcs": attr.label_list(allow_files = True),
+        "srcs": attr.label_list(
+            allow_empty = False,
+            allow_files = True,
+        ),
         "deps": attr.label_list(),
         "doctitle": attr.string(default = ""),
         "root_packages": attr.string_list(),


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Don't allow an empty list of Javadoc sources. The javadoc tool will complain if you do so.

See https://github.com/google/bazel-common/issues/58 for an example where this produced an opaque error

Fixes https://github.com/google/bazel-common/issues/58

df26b3c30460f7274f1808c7f41f85f1bc2e2645

-------

<p> Support runtime_deps.

c68e09e70a11a5e2c62a520eba9b91627fcfd966