### PR TITLE
Support JavaInfo provider in javadoc_library

### DIFF
--- a/tools/javadoc/javadoc.bzl
+++ b/tools/javadoc/javadoc.bzl
@@ -24,7 +24,13 @@ def _android_jar(android_api_level):
 def _javadoc_library(ctx):
     _check_non_empty(ctx.attr.root_packages, "root_packages")
 
-    transitive_deps = [dep.java.transitive_deps for dep in ctx.attr.deps]
+    transitive_deps = []
+    for dep in ctx.attr.deps:
+        if JavaInfo in dep:
+            transitive_deps.append(dep[JavaInfo].transitive_deps)
+        elif hasattr(dep, "java"):
+            transitive_deps.append(dep.java.transitive_deps)
+
     if ctx.attr._android_jar:
         transitive_deps.append(ctx.attr._android_jar.files)
 


### PR DESCRIPTION
Preparation for https://github.com/bazelbuild/bazel/issues/7598.

Resolves https://github.com/google/bazel-common/issues/75.

Testing Done:
- Used `javadoc_library` in a project with custom Java rules which only export
  the `JavaInfo` provider.