### PR TITLE
Moe Sync

### DIFF
--- a/tools/javadoc/javadoc.bzl
+++ b/tools/javadoc/javadoc.bzl
@@ -24,7 +24,13 @@ def _android_jar(android_api_level):
 def _javadoc_library(ctx):
     _check_non_empty(ctx.attr.root_packages, "root_packages")
 
-    transitive_deps = [dep.java.transitive_deps for dep in ctx.attr.deps]
+    transitive_deps = []
+    for dep in ctx.attr.deps:
+        if JavaInfo in dep:
+            transitive_deps.append(dep[JavaInfo].transitive_deps)
+        elif hasattr(dep, "java"):
+            transitive_deps.append(dep.java.transitive_deps)
+
     if ctx.attr._android_jar:
         transitive_deps.append(ctx.attr._android_jar.files)
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Support JavaInfo provider in javadoc_library

Preparation for https://github.com/bazelbuild/bazel/issues/7598.

Closes https://github.com/google/bazel-common/issues/75.
Resolves https://github.com/google/bazel-common/issues/76.

Testing Done:
- `./build_test.sh`
- Used `javadoc_library` in a project with custom Java rules which only export
  the `JavaInfo` provider.

993b8f0c362a7ab7e39dc7d3591f785a69d5d197