### PR TITLE
deplist.to_list() fixed.

### DIFF
--- a/tools/maven/pom_file.bzl
+++ b/tools/maven/pom_file.bzl
@@ -117,7 +117,7 @@ def _sort_artifacts(artifacts, prefixes):
       A new, sorted list containing the contents of `artifacts`.
     """
     indexed = []
-    for artifact in artifacts:
+    for artifact in artifacts.to_list():
         parts = artifact.split(":")
         indexed.append((_prefix_index_of(parts[0], prefixes), parts, artifact))
 


### PR DESCRIPTION
here I faced an exception with bazel version 0.27.2。

```
ERROR: /Users/lianxin.wlx/projects/X/ray/java/BUILD.bazel:273:1: in pom_file rule //java:org_ray_ray_api_pom:
Traceback (most recent call last):
	File "/Users/lianxin.wlx/projects/X/ray/java/BUILD.bazel", line 273
		pom_file(name = 'org_ray_ray_api_pom')
	File "/private/var/tmp/_bazel_lianxin.wlx/cf2af1ea2d276e572e6b840241963395/external/bazel_common/tools/maven/pom_file.bzl", line 151, in _pom_file
		_sort_artifacts(mvn_deps, ctx.attr.preferred_group...)
	File "/private/var/tmp/_bazel_lianxin.wlx/cf2af1ea2d276e572e6b840241963395/external/bazel_common/tools/maven/pom_file.bzl", line 120, in _sort_artifacts
		for artifact in artifacts: ...
type 'depset' is not iterable. Use the `to_list()` method to get a list. Use --incompatible_depset_is_not_iterable=false to temporarily disable this check.
```

it seems that bazel has removed the iterator of depset in latest versions.

and I add a to_list() to the corresponding  line.