### PR TITLE
Moe Sync

### DIFF
--- a/third_party/java/checker_framework/BUILD
+++ b/third_party/java/checker_framework/BUILD
@@ -14,7 +14,7 @@
 
 # BUILD rules for https://checkerframework.org/
 
-licenses(["restricted"])  # GPLv2 with "Classpath" exception
+licenses(["restricted"])
 
 package(default_visibility = ["//visibility:public"])
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Remove GPLv2 and GPL2 comments from BUILD files in third_party.  The LICENSE file is canonical, and these comments can get out of date or just be wrong.

Fix many (but not all) licenses() directives which were obviously wrong.  For example, several packages with a LGPL LICENSES file did not have licenses(['restricted']) but instead had something less restrictive.

2df23e213b3913de0a05d1dd9ec152374f2f7c24