### PR TITLE
Moe Sync

### DIFF
--- a/third_party/java/byte_buddy/BUILD
+++ b/third_party/java/byte_buddy/BUILD
@@ -21,5 +21,5 @@ package(default_visibility = ["//visibility:public"])
 java_library(
     name = "byte_buddy",
     testonly = 1,
-    exports = ["@byte_buddy//jar"],
+    exports = ["@net_bytebuddy_byte_buddy//jar"],
 )

--- a/third_party/java/byte_buddy/BUILD
+++ b/third_party/java/byte_buddy/BUILD
@@ -19,13 +19,7 @@ licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
 package(default_visibility = ["//visibility:public"])
 
 java_library(
-    name = "mockito",
+    name = "byte_buddy",
     testonly = 1,
-    exports = ["@org_mockito_mockito_core//jar"],
-    runtime_deps = [
-        "//third_party/java/byte_buddy",
-        "//third_party/java/byte_buddy_agent",
-        "//third_party/java/hamcrest",
-        "//third_party/java/objenesis",
-    ],
+    exports = ["@byte_buddy//jar"],
 )

--- a/third_party/java/byte_buddy_agent/BUILD
+++ b/third_party/java/byte_buddy_agent/BUILD
@@ -21,5 +21,5 @@ package(default_visibility = ["//visibility:public"])
 java_library(
     name = "byte_buddy_agent",
     testonly = 1,
-    exports = ["@byte_buddy_agent//jar"],
+    exports = ["@net_bytebuddy_byte_buddy_agent//jar"],
 )

--- a/third_party/java/byte_buddy_agent/BUILD
+++ b/third_party/java/byte_buddy_agent/BUILD
@@ -19,13 +19,7 @@ licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
 package(default_visibility = ["//visibility:public"])
 
 java_library(
-    name = "mockito",
+    name = "byte_buddy_agent",
     testonly = 1,
-    exports = ["@org_mockito_mockito_core//jar"],
-    runtime_deps = [
-        "//third_party/java/byte_buddy",
-        "//third_party/java/byte_buddy_agent",
-        "//third_party/java/hamcrest",
-        "//third_party/java/objenesis",
-    ],
+    exports = ["@byte_buddy_agent//jar"],
 )

--- a/workspace_defs.bzl
+++ b/workspace_defs.bzl
@@ -175,9 +175,21 @@ def google_common_workspace_rules():
     )
 
     _maven_import(
-        artifact = "org.mockito:mockito-core:1.9.5",
+        artifact = "net.bytebuddy:byte-buddy:1.9.10",
         licenses = ["notice"],
-        sha256 = "f97483ba0944b9fa133aa29638764ddbeadb51ec3dbc02074c58fa2caecd07fa",
+        sha256 = "2936debc4d7b6c534848d361412e2d0f8bd06f7f27a6f4e728a20e97648d2bf3",
+    )
+
+    _maven_import(
+        artifact = "net.bytebuddy:byte-buddy-agent:1.9.10",
+        licenses = ["notice"],
+        sha256 = "8ed739d29132103250d307d2e8e3c95f07588ef0543ab11d2881d00768a5e182",
+    )
+
+    _maven_import(
+        artifact = "org.mockito:mockito-core:2.28.2",
+        licenses = ["notice"],
+        sha256 = "b0af36fed3a6c2147c0cd9028a1d814fd4f4e8196c539f2befddb61ca6ec9e27",
     )
 
     _maven_import(


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Update mockito-core to 2.28.0 and include byte-buddy

This is necessary to update other third_party projects like Dagger which depend on this version ([]

d3fb9a65f878fc2fe71825cafddd99a93bd00627

-------

<p> Fix the bytebuddy repository names

I totally missed this on the previous review

413a129be8f6b4daac0426fddc6e8e052580b370