### PR TITLE
Add a gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Generated bazel symlinks.
+/bazel-*


### PR DESCRIPTION
This is set to ignore the symlinks created by Bazel.