### PR TITLE
Update Skylib to 0.9.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,3 +17,7 @@ workspace(name = "google_bazel_common")
 load("//:workspace_defs.bzl", "google_common_workspace_rules")
 
 google_common_workspace_rules()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()

--- a/workspace_defs.bzl
+++ b/workspace_defs.bzl
@@ -417,11 +417,14 @@ def google_common_workspace_rules():
         sha256 = "c35697e7ad4bab018156cc3b75e8742f31fd8cad5bb9762f25bbf669ce01abce",
     )
 
-    skylib_version = "9430df29e4c648b95bf39a57e4336b44a0a0582a"
+    skylib_version = "0.9.0"
     http_archive(
         name = "bazel_skylib",
-        strip_prefix = "bazel-skylib-{}".format(skylib_version),
-        urls = ["https://github.com/bazelbuild/bazel-skylib/archive/{}.zip".format(skylib_version)],
+        url = "https://github.com/bazelbuild/bazel-skylib/releases/download/{}/bazel_skylib-{}.tar.gz".format(
+            skylib_version,
+            skylib_version,
+        ),
+        sha256 = "1dde365491125a3db70731e25658dfdd3bc5dbdfd11b840b3e987ecf043c7ca0",
     )
 
     _maven_import(


### PR DESCRIPTION
This is needed to run the tests with Bazel 0.27+ (https://github.com/bazelbuild/bazel/issues/5816)

The problematic usages are in `//tools/maven:pom_file.bzl`, `_maven_info_test_impl` (and maybe others). The tests are now passing just fine with Bazel 0.29.1. It might be worth updating Travis to run on a more recent version, as it's [currently using Bazel 0.24.1](https://github.com/google/bazel-common/blob/master/.travis.yml#L40).