### PR TITLE
MOE Sync 2020-01-16

### DIFF
--- a/workspace_defs.bzl
+++ b/workspace_defs.bzl
@@ -18,7 +18,7 @@ load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
 
 _MAVEN_MIRRORS = [
     "http://bazel-mirror.storage.googleapis.com/repo1.maven.org/maven2/",
-    "http://repo1.maven.org/maven2/",
+    "https://repo1.maven.org/maven2/",
     "http://maven.ibiblio.org/maven2/",
 ]
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Update sonatype maven repository to use https in _maven_install

This is now a requirement of sonatype as of 01/15/2020

  https://support.sonatype.com/hc/en-us/articles/360041287334

It's currently causing failures on travis. In particular, builds that passed 2 days ago are now failing today (https://travis-ci.org/google/dagger/builds/636502706):

WARNING: Download from http://repo1.maven.org/maven2/com/squareup/javapoet/1.11.1/javapoet-1.11.1.jar failed: class GET returned 501 HTTPS Required

ERROR: An error occurred during the fetch of repository 'com_squareup_javapoet':

3eb6b1361329f18480f1b05a37b01014e29d20fe