### PR TITLE
MOE Sync 2020-01-17

### DIFF
--- a/workspace_defs.bzl
+++ b/workspace_defs.bzl
@@ -374,9 +374,9 @@ def google_common_workspace_rules():
     )
 
     _maven_import(
-        artifact = "org.pantsbuild:jarjar:1.6.3",
+        artifact = "org.pantsbuild:jarjar:1.7.2",
         licenses = ["notice"],
-        sha256 = "dbcc085f6db9dc8fc71cb18ff0e6f87ecade1dd9ad3a9b85bdc8da3fef76c018",
+        sha256 = "0706a455e17b67718abe212e3a77688bbe8260852fc74e3e836d9f2e76d91c27",
     )
 
     _maven_import(


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Update bazel_common to org.pantsbuild:jarjar:1.7.2

This fixes bazel_common's `jarjar_library` which I think was broken when updating to `org.ow2.asm:asm-commons:7.2`.

The issue is that `org.pantsbuild:jarjar:1.6.3` was depending on a class that is removed in the new version of asm-commons:

  java.lang.NoClassDefFoundError: org/objectweb/asm/commons/RemappingClassAdapter

so we need to also update pantsbuild.

I've verified locally that upgrading from 1.6.3 to 1.7.2 fixes the `jarjar_library` for Dagger.

842dd97068470df6ab66a9c69ce9ef2524a78df3