### PR TITLE
MOE Sync 2020-02-04

### DIFF
--- a/tools/maven/pom_file.bzl
+++ b/tools/maven/pom_file.bzl
@@ -239,15 +239,15 @@ def _fake_java_library(name, deps = None, exports = None):
 
 def _maven_info_test_impl(ctx):
     env = unittest.begin(ctx)
-    asserts.set_equals(
+    asserts.equals(
         env,
-        expected = depset(ctx.attr.maven_artifacts),
+        expected = ctx.attr.maven_artifacts,
         actual = ctx.attr.target[MavenInfo].maven_artifacts,
         msg = "MavenInfo.maven_artifacts",
     )
-    asserts.set_equals(
+    asserts.equals(
         env,
-        expected = depset(ctx.attr.maven_dependencies),
+        expected = ctx.attr.maven_dependencies,
         actual = ctx.attr.target[MavenInfo].maven_dependencies,
         msg = "MavenInfo.maven_dependencies",
     )


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Remove references to asserts.set_equals

The old set type is going away.

cb92cf926dbd5bbebfb120321d52e5fbc8a118a5