### PR TITLE
MOE Sync 2020-02-23

### DIFF
--- a/testing/test_defs.bzl
+++ b/testing/test_defs.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Skylark macros to simplify declaring tests."""
 
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
 
 def gen_java_tests(
         name,
@@ -40,8 +41,8 @@ def gen_java_tests(
     and `java_test`s that have `deps = [:a, :c]`.
     """
     _gen_java_tests(
-        native.java_library,
-        native.java_test,
+        java_library,
+        java_test,
         name,
         srcs,
         deps,

--- a/third_party/java/apache_bcel/BUILD
+++ b/third_party/java/apache_bcel/BUILD
@@ -14,6 +14,8 @@
 
 # BUILD rules for https://commons.apache.org/proper/commons-bcel/
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/java/asm/BUILD
+++ b/third_party/java/asm/BUILD
@@ -14,6 +14,8 @@
 
 # BUILD rules for http://asm.ow2.org/
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 licenses(["notice"])  # BSD
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/java/auto/BUILD
+++ b/third_party/java/auto/BUILD
@@ -14,6 +14,8 @@
 
 # BUILD rules for https://github.com/google/auto
 
+load("@rules_java//java:defs.bzl", "java_library", "java_plugin")
+
 licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/java/byte_buddy/BUILD
+++ b/third_party/java/byte_buddy/BUILD
@@ -14,6 +14,8 @@
 
 # BUILD rules for https://github.com/mockito/mockito
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/java/byte_buddy_agent/BUILD
+++ b/third_party/java/byte_buddy_agent/BUILD
@@ -14,6 +14,8 @@
 
 # BUILD rules for https://github.com/mockito/mockito
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/java/checker_framework/BUILD
+++ b/third_party/java/checker_framework/BUILD
@@ -14,6 +14,8 @@
 
 # BUILD rules for https://checkerframework.org/
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 licenses(["restricted"])
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/java/checker_framework_annotations/BUILD
+++ b/third_party/java/checker_framework_annotations/BUILD
@@ -14,6 +14,8 @@
 
 # BUILD rules for https://checkerframework.org/
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 licenses(["notice"])  # MIT
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/java/compile_testing/BUILD
+++ b/third_party/java/compile_testing/BUILD
@@ -14,6 +14,8 @@
 
 # BUILD rules for https://github.com/google/compile-testing
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/java/error_prone/BUILD
+++ b/third_party/java/error_prone/BUILD
@@ -16,6 +16,8 @@
 # applies the Error Prone compiler to all java compilations - this package exports
 # dependencies for Error Prone's libraries
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/java/google_java_format/BUILD
+++ b/third_party/java/google_java_format/BUILD
@@ -14,6 +14,8 @@
 
 # BUILD rules for https://github.com/google/google-java-format
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/java/grpc/BUILD
+++ b/third_party/java/grpc/BUILD
@@ -14,6 +14,8 @@
 
 # BUILD rules for https://github.com/grpc/grpc-java
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/java/guava/BUILD
+++ b/third_party/java/guava/BUILD
@@ -14,6 +14,8 @@
 
 # BUILD rules for https://github.com/google/guava
 
+load("@rules_java//java:defs.bzl", "java_library", "java_plugin")
+
 licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/java/hamcrest/BUILD
+++ b/third_party/java/hamcrest/BUILD
@@ -14,6 +14,8 @@
 
 # BUILD rules for https://github.com/hamcrest/JavaHamcrest
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/java/incap/BUILD
+++ b/third_party/java/incap/BUILD
@@ -14,6 +14,8 @@
 
 # BUILD rules for https://github.com/tbroyer/gradle-incap-helper
 
+load("@rules_java//java:defs.bzl", "java_library", "java_plugin")
+
 licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/java/inject_common/BUILD
+++ b/third_party/java/inject_common/BUILD
@@ -14,6 +14,8 @@
 
 # BUILD rules for https://github.com/google/inject-common
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/java/javapoet/BUILD
+++ b/third_party/java/javapoet/BUILD
@@ -14,6 +14,8 @@
 
 # BUILD rules for https://github.com/square/javapoet
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/java/jsr250_annotations/BUILD
+++ b/third_party/java/jsr250_annotations/BUILD
@@ -14,6 +14,8 @@
 
 # BUILD rules for https://en.wikipedia.org/wiki/JSR_250
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/java/jsr305_annotations/BUILD
+++ b/third_party/java/jsr305_annotations/BUILD
@@ -14,6 +14,8 @@
 
 # BUILD rules for https://jcp.org/en/jsr/detail?id=305
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/java/jsr330_inject/BUILD
+++ b/third_party/java/jsr330_inject/BUILD
@@ -14,6 +14,8 @@
 
 # BUILD rules for javax.inject (https://www.jcp.org/en/jsr/detail?id=330)
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/java/junit/BUILD
+++ b/third_party/java/junit/BUILD
@@ -14,6 +14,8 @@
 
 # BUILD rules for https://github.com/junit-team
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/java/log4j/BUILD
+++ b/third_party/java/log4j/BUILD
@@ -14,6 +14,8 @@
 
 # BUILD rules for https://logging.apache.org/log4j/1.2
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/java/log4j2/BUILD
+++ b/third_party/java/log4j2/BUILD
@@ -14,6 +14,8 @@
 
 # BUILD rules for https://logging.apache.org/log4j/2.x/
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/java/mockito/BUILD
+++ b/third_party/java/mockito/BUILD
@@ -14,6 +14,8 @@
 
 # BUILD rules for https://github.com/mockito/mockito
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/java/objenesis/BUILD
+++ b/third_party/java/objenesis/BUILD
@@ -14,6 +14,8 @@
 
 # BUILD rules for https://github.com/mockito/mockito
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/java/protobuf/BUILD
+++ b/third_party/java/protobuf/BUILD
@@ -14,6 +14,8 @@
 
 # BUILD rules for https://github.com/google/protobuf/tree/master/java
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/java/slf4j_api/BUILD
+++ b/third_party/java/slf4j_api/BUILD
@@ -14,6 +14,8 @@
 
 # BUILD rules for org.slf4j:slf4j-api
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 licenses(["notice"])  # MIT
 
 package(default_visibility = ["//visibility:public"])

--- a/third_party/java/truth/BUILD
+++ b/third_party/java/truth/BUILD
@@ -14,6 +14,8 @@
 
 # BUILD rules for https://github.com/google/truth
 
+load("@rules_java//java:defs.bzl", "java_library")
+
 licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
 
 package(default_visibility = ["//visibility:public"])

--- a/tools/jarjar/BUILD
+++ b/tools/jarjar/BUILD
@@ -14,6 +14,7 @@
 
 # Skylark rules for using jarjar
 
+load("@rules_java//java:defs.bzl", "java_binary")
 load(":jarjar.bzl", "jarjar_library")
 
 licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE

--- a/tools/maven/pom_file.bzl
+++ b/tools/maven/pom_file.bzl
@@ -14,6 +14,7 @@
 """Skylark rules to make publishing Maven artifacts simpler.
 """
 
+load("@rules_java//java:defs.bzl", "java_library")
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 
 MavenInfo = provider(
@@ -229,7 +230,7 @@ def _fake_java_library(name, deps = None, exports = None):
         outs = src_file,
         cmd = "echo 'class %s {}' > $@" % name,
     )
-    native.java_library(
+    java_library(
         name = name,
         srcs = src_file,
         tags = ["maven_coordinates=%s:_:_" % name],

--- a/workspace_defs.bzl
+++ b/workspace_defs.bzl
@@ -30,11 +30,14 @@ def _maven_import(artifact, sha256, licenses, **kwargs):
     name = ("%s_%s" % (group_id, artifact_id)).replace(".", "_").replace("-", "_")
     url_suffix = "{0}/{1}/{2}/{1}-{2}.jar".format(group_id.replace(".", "/"), artifact_id, version)
 
+    # TODO(cpovirk): Consider jvm_maven_import_external.
     java_import_external(
         name = name,
         jar_urls = [base + url_suffix for base in _MAVEN_MIRRORS],
         jar_sha256 = sha256,
         licenses = licenses,
+        # TODO(cpovirk): Remove after https://github.com/bazelbuild/bazel/issues/10838 is fixed.
+        rule_load = """load("@rules_java//java:defs.bzl", "java_import")""",
         tags = ["maven_coordinates=" + artifact],
         **kwargs
     )
@@ -265,13 +268,11 @@ def google_common_workspace_rules():
     )
 
     for protobuf_repo in ("com_google_protobuf", "com_google_protobuf_java"):
-        # Based on 3.7.x branch. 3.7.0's tag was missing a fix to build with bazel
-        # TODO(user,ronshapiro): update to the next available tagged released when possible
         http_archive(
             name = protobuf_repo,
-            sha256 = "64bde341a59bd4abca6bee85cbc5372ee0eff7a20bf07815931096efc2b58a40",
-            strip_prefix = "protobuf-57b6597f467c2b614a458051f60ba467c5d697ae",
-            urls = ["https://github.com/protocolbuffers/protobuf/archive/57b6597f467c2b614a458051f60ba467c5d697ae.zip"],
+            sha256 = "9748c0d90e54ea09e5e75fb7fac16edce15d2028d4356f32211cfa3c0e956564",
+            strip_prefix = "protobuf-3.11.4",
+            urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.11.4.zip"],
         )
 
     CHECKER_FRAMEWORK_VERSION = "2.5.3"


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Prepare for --incompatible_load_java_rules_from_bzl.

Fixes https://github.com/google/bazel-common/issues/97
Progress toward https://github.com/google/flogger/issues/122

I have also tested this against Flogger and Dagger (modified to fix their own --incompatible_load_java_rules_from_bzl problems). Everything appears to work except for Dagger, which has some breakages from bazel_tools itself, for which I have filed https://github.com/bazelbuild/bazel/issues/10839. (This is in addition to filing and working around https://github.com/bazelbuild/bazel/issues/10838.)

It also includes an upgrade to rules_kotlin to contain the analogous fix for that repo: https://github.com/bazelbuild/rules_kotlin/commit/186c1e1e27d699a8953b75461f2de7c295987cfb

And ditto for protobuf.

50621556258fd64b265f1cf62a9c5fc2d2c1aba1