### PR TITLE
Update JavaPoet to 1.12.1

### DIFF
--- a/workspace_defs.bzl
+++ b/workspace_defs.bzl
@@ -220,9 +220,9 @@ def google_common_workspace_rules():
     )
 
     _maven_import(
-        artifact = "com.squareup:javapoet:1.11.1",
+        artifact = "com.squareup:javapoet:1.12.1",
         licenses = ["notice"],
-        sha256 = "9cbf2107be499ec6e95afd36b58e3ca122a24166cdd375732e51267d64058e90",
+        sha256 = "e961908e4e3a460ad25acfd240157978b0307acd106691c190efa855cf05eafd",
     )
 
     _maven_import(

--- a/workspace_defs.bzl
+++ b/workspace_defs.bzl
@@ -222,7 +222,7 @@ def google_common_workspace_rules():
     _maven_import(
         artifact = "com.squareup:javapoet:1.13.0",
         licenses = ["notice"],
-        sha256 = "e961908e4e3a460ad25acfd240157978b0307acd106691c190efa855cf05eafd",
+        sha256 = "4c7517e848a71b36d069d12bb3bf46a70fd4cda3105d822b0ed2e19c00b69291",
     )
 
     _maven_import(

--- a/workspace_defs.bzl
+++ b/workspace_defs.bzl
@@ -220,7 +220,7 @@ def google_common_workspace_rules():
     )
 
     _maven_import(
-        artifact = "com.squareup:javapoet:1.12.1",
+        artifact = "com.squareup:javapoet:1.13.0",
         licenses = ["notice"],
         sha256 = "e961908e4e3a460ad25acfd240157978b0307acd106691c190efa855cf05eafd",
     )


### PR DESCRIPTION
JavaPoet 1.12 is commonly used in other processors but contained a bug that causes errors in Dagger. This updates the common definition to 1.12.1, which contains a fix. See https://github.com/google/dagger/issues/1715 for more context.