### PR TITLE
MOE Sync 2020-06-10

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -15,6 +15,4 @@
 # Common configuration and dependencies for Google's open-source libraries that are built with
 # Bazel.
 
-licenses(["notice"])  # Apache 2.0 License
-
 exports_files(["LICENSE"])

--- a/testing/BUILD
+++ b/testing/BUILD
@@ -13,5 +13,3 @@
 # limitations under the License.
 
 # A collection of skylark marcors and rules for testing
-
-licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE

--- a/third_party/java/apache_bcel/BUILD
+++ b/third_party/java/apache_bcel/BUILD
@@ -16,8 +16,6 @@
 
 load("@rules_java//java:defs.bzl", "java_library")
 
-licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
-
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/third_party/java/asm/BUILD
+++ b/third_party/java/asm/BUILD
@@ -16,8 +16,6 @@
 
 load("@rules_java//java:defs.bzl", "java_library")
 
-licenses(["notice"])  # BSD
-
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/third_party/java/auto/BUILD
+++ b/third_party/java/auto/BUILD
@@ -16,8 +16,6 @@
 
 load("@rules_java//java:defs.bzl", "java_library", "java_plugin")
 
-licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
-
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/third_party/java/byte_buddy/BUILD
+++ b/third_party/java/byte_buddy/BUILD
@@ -16,8 +16,6 @@
 
 load("@rules_java//java:defs.bzl", "java_library")
 
-licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
-
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/third_party/java/byte_buddy_agent/BUILD
+++ b/third_party/java/byte_buddy_agent/BUILD
@@ -16,8 +16,6 @@
 
 load("@rules_java//java:defs.bzl", "java_library")
 
-licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
-
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/third_party/java/checker_framework/BUILD
+++ b/third_party/java/checker_framework/BUILD
@@ -16,8 +16,6 @@
 
 load("@rules_java//java:defs.bzl", "java_library")
 
-licenses(["restricted"])
-
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/third_party/java/checker_framework_annotations/BUILD
+++ b/third_party/java/checker_framework_annotations/BUILD
@@ -16,8 +16,6 @@
 
 load("@rules_java//java:defs.bzl", "java_library")
 
-licenses(["notice"])  # MIT
-
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/third_party/java/compile_testing/BUILD
+++ b/third_party/java/compile_testing/BUILD
@@ -16,8 +16,6 @@
 
 load("@rules_java//java:defs.bzl", "java_library")
 
-licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
-
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/third_party/java/error_prone/BUILD
+++ b/third_party/java/error_prone/BUILD
@@ -18,8 +18,6 @@
 
 load("@rules_java//java:defs.bzl", "java_library")
 
-licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
-
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/third_party/java/google_java_format/BUILD
+++ b/third_party/java/google_java_format/BUILD
@@ -16,8 +16,6 @@
 
 load("@rules_java//java:defs.bzl", "java_library")
 
-licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
-
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/third_party/java/grpc/BUILD
+++ b/third_party/java/grpc/BUILD
@@ -16,8 +16,6 @@
 
 load("@rules_java//java:defs.bzl", "java_library")
 
-licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
-
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/third_party/java/guava/BUILD
+++ b/third_party/java/guava/BUILD
@@ -16,8 +16,6 @@
 
 load("@rules_java//java:defs.bzl", "java_library", "java_plugin")
 
-licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
-
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/third_party/java/hamcrest/BUILD
+++ b/third_party/java/hamcrest/BUILD
@@ -16,8 +16,6 @@
 
 load("@rules_java//java:defs.bzl", "java_library")
 
-licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
-
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/third_party/java/incap/BUILD
+++ b/third_party/java/incap/BUILD
@@ -16,8 +16,6 @@
 
 load("@rules_java//java:defs.bzl", "java_library", "java_plugin")
 
-licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
-
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/third_party/java/inject_common/BUILD
+++ b/third_party/java/inject_common/BUILD
@@ -16,8 +16,6 @@
 
 load("@rules_java//java:defs.bzl", "java_library")
 
-licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
-
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/third_party/java/javapoet/BUILD
+++ b/third_party/java/javapoet/BUILD
@@ -16,8 +16,6 @@
 
 load("@rules_java//java:defs.bzl", "java_library")
 
-licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
-
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/third_party/java/jsr250_annotations/BUILD
+++ b/third_party/java/jsr250_annotations/BUILD
@@ -16,8 +16,6 @@
 
 load("@rules_java//java:defs.bzl", "java_library")
 
-licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
-
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/third_party/java/jsr305_annotations/BUILD
+++ b/third_party/java/jsr305_annotations/BUILD
@@ -16,8 +16,6 @@
 
 load("@rules_java//java:defs.bzl", "java_library")
 
-licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
-
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/third_party/java/jsr330_inject/BUILD
+++ b/third_party/java/jsr330_inject/BUILD
@@ -16,8 +16,6 @@
 
 load("@rules_java//java:defs.bzl", "java_library")
 
-licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
-
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/third_party/java/junit/BUILD
+++ b/third_party/java/junit/BUILD
@@ -16,8 +16,6 @@
 
 load("@rules_java//java:defs.bzl", "java_library")
 
-licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
-
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/third_party/java/log4j/BUILD
+++ b/third_party/java/log4j/BUILD
@@ -16,8 +16,6 @@
 
 load("@rules_java//java:defs.bzl", "java_library")
 
-licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
-
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/third_party/java/log4j2/BUILD
+++ b/third_party/java/log4j2/BUILD
@@ -16,8 +16,6 @@
 
 load("@rules_java//java:defs.bzl", "java_library")
 
-licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
-
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/third_party/java/mockito/BUILD
+++ b/third_party/java/mockito/BUILD
@@ -16,8 +16,6 @@
 
 load("@rules_java//java:defs.bzl", "java_library")
 
-licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
-
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/third_party/java/objenesis/BUILD
+++ b/third_party/java/objenesis/BUILD
@@ -16,8 +16,6 @@
 
 load("@rules_java//java:defs.bzl", "java_library")
 
-licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
-
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/third_party/java/protobuf/BUILD
+++ b/third_party/java/protobuf/BUILD
@@ -16,8 +16,6 @@
 
 load("@rules_java//java:defs.bzl", "java_library")
 
-licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
-
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/third_party/java/slf4j_api/BUILD
+++ b/third_party/java/slf4j_api/BUILD
@@ -16,8 +16,6 @@
 
 load("@rules_java//java:defs.bzl", "java_library")
 
-licenses(["notice"])  # MIT
-
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/third_party/java/truth/BUILD
+++ b/third_party/java/truth/BUILD
@@ -16,8 +16,6 @@
 
 load("@rules_java//java:defs.bzl", "java_library")
 
-licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
-
 package(default_visibility = ["//visibility:public"])
 
 java_library(

--- a/tools/jarjar/BUILD
+++ b/tools/jarjar/BUILD
@@ -17,8 +17,6 @@
 load("@rules_java//java:defs.bzl", "java_binary")
 load(":jarjar.bzl", "jarjar_library")
 
-licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
-
 java_binary(
     name = "jarjar",
     main_class = "org.pantsbuild.jarjar.Main",

--- a/tools/javadoc/BUILD
+++ b/tools/javadoc/BUILD
@@ -13,5 +13,3 @@
 # limitations under the License.
 
 # Skylark rules for generating Javadoc
-
-licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE

--- a/tools/maven/BUILD
+++ b/tools/maven/BUILD
@@ -14,8 +14,6 @@
 
 # Skylark rules for generating Maven pom files
 
-licenses(["notice"])  # Apache 2.0 LICENSE at //LICENSE
-
 load(":pom_file.bzl", "pom_file_tests")
 
 # TODO(ronshapiro): Set up a travis build


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Strip licenses() directives.

They became redundant when we switched from maven_jar to
java_import_external (which has its own licenses parameter, which is
used to generate a licenses() directive).

88a7914fbeb407c8c166992ac855578ac8d5b7f8