### PR TITLE
MOE Sync 2020-06-29

### DIFF
--- a/workspace_defs.bzl
+++ b/workspace_defs.bzl
@@ -220,9 +220,9 @@ def google_common_workspace_rules():
     )
 
     _maven_import(
-        artifact = "com.squareup:javapoet:1.11.1",
+        artifact = "com.squareup:javapoet:1.13.0",
         licenses = ["notice"],
-        sha256 = "9cbf2107be499ec6e95afd36b58e3ca122a24166cdd375732e51267d64058e90",
+        sha256 = "4c7517e848a71b36d069d12bb3bf46a70fd4cda3105d822b0ed2e19c00b69291",
     )
 
     _maven_import(


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Update JavaPoet to 1.13.0

JavaPoet is commonly used in other processors but contained a bug that causes errors in Dagger. This updates the common definition to 1.13.0, which contains a fix for Dagger & Hilt.

See https://github.com/google/dagger/issues/1715
and https://github.com/google/dagger/issues/1909 for more context.

Closes https://github.com/google/bazel-common/pull/105

0b820e4b1cdc019ce66956c46586ebadba7baad1