### PR TITLE
Please update to use current Checker Framework artifact

### DIFF
--- a/third_party/java/checker_framework_annotations/BUILD
+++ b/third_party/java/checker_framework_annotations/BUILD
@@ -20,5 +20,5 @@ package(default_visibility = ["//visibility:public"])
 
 java_library(
     name = "checker_framework_annotations",
-    exports = ["@org_checkerframework_checker_compat_qual//jar"],
+    exports = ["@org_checkerframework_checker_qual//jar"],
 )


### PR DESCRIPTION
The checker-compat-qual artifact has been [removed for almost two years](https://github.com/typetools/checker-framework/releases/tag/checker-framework-2.5.6) and deprecated prior to that. Using the current version here will allow downstream users, e.g. [Flogger](https://travis-ci.org/github/google/flogger/builds/703726380), to migrate to the current version of Checker Framework.