### PR TITLE
Teach javadoc_library about tree artifacts

### DIFF
--- a/tools/javadoc/BUILD
+++ b/tools/javadoc/BUILD
@@ -13,3 +13,6 @@
 # limitations under the License.
 
 # Starlark rules for generating Javadoc
+load(":tests.bzl", "analysis_test_suite")
+
+analysis_test_suite(name = "javadoc_suite")

--- a/tools/javadoc/javadoc.bzl
+++ b/tools/javadoc/javadoc.bzl
@@ -45,11 +45,7 @@ def _javadoc_library(ctx):
     args.use_param_file(param_file_arg = "@%s", use_always = True)
     args.add("-use")
     args.add("-encoding", "UTF8")
-    args.add_joined(
-        "-classpath",
-        classpath,
-        join_with = java_pathsep,
-    )
+    args.add_joined("-classpath", classpath, join_with = java_pathsep)
     args.add("-notimestamp")
     args.add("-d", output_dir.path)
     args.add("-Xdoclint:-missing")

--- a/tools/javadoc/javadoc.bzl
+++ b/tools/javadoc/javadoc.bzl
@@ -54,10 +54,6 @@ def _javadoc_library(ctx):
     # Documentation for the javadoc command
     # https://docs.oracle.com/javase/9/javadoc/javadoc-command.htm
     if ctx.attr.root_packages:
-        # TODO(b/167433657): Reevaluate the utility of root_packages
-        # 1. Find the first directory under the working directory named '*java'.
-        # 2. Assume all files to document can be found by appending a root_package name
-        #    to that directory, or a subdirectory, replacting dots with slashes.
         args.add_all(ctx.attr.root_packages)
         args.add_joined("-subpackages", ctx.attr.root_packages, join_with = java_pathsep)
     else:
@@ -88,8 +84,11 @@ def _javadoc_library(ctx):
         outputs = [output_dir],
         arguments = [args],
         command = "${JAVA_HOME}/bin/javadoc $1" + (
-            # See TODO(b/167433657) above.
-            ' -sourcepath "$(find * -type d -name \'*java\' -print0 | tr \'\\0\' :)"' if ctx.attr.root_packages else ""
+            # TODO(b/167433657): Reevaluate the utility of root_packages
+            # 1. Find the first directory under the working directory named '*java'.
+            # 2. Assume all files to document can be found by appending a root_package name
+            #    to that directory, or a subdirectory, replacting dots with slashes.
+            r""" -sourcepath "$(find * -type d -name '*java' -print0 | tr '\0' :)" """ if ctx.attr.root_packages else ""
         ),
         env = {"JAVA_HOME": java_home},
     )

--- a/tools/javadoc/javadoc.bzl
+++ b/tools/javadoc/javadoc.bzl
@@ -128,7 +128,7 @@ outjar=$1; shift
 
 cd $outdir
 zargsfile=$OLDPWD/${outdir}.tmp
-find . -type f | LC_ALL=C sort > $zargsfile
+find * -type f | LC_ALL=C sort > $zargsfile
 $OLDPWD/$zipper Cc $OLDPWD/$outjar @$zargsfile
 """,
     )

--- a/tools/javadoc/tests.bzl
+++ b/tools/javadoc/tests.bzl
@@ -62,7 +62,7 @@ def _deps_test_case(name):
         tags = ["manual"],
     )
     _deps_test(
-        name = name + "_test",
+        name = name,
         target_under_test = name + "_javadoc",
     )
 
@@ -104,7 +104,7 @@ def _group_test_case(name):
         tags = ["manual"],
     )
     _group_test(
-        name = name + "_test",
+        name = name,
         target_under_test = name + "_javadoc",
     )
 
@@ -134,7 +134,7 @@ def _links_test_case(name):
         tags = ["manual"],
     )
     _links_test(
-        name = name + "_test",
+        name = name,
         target_under_test = name + "_javadoc",
     )
 
@@ -181,22 +181,22 @@ def _root_packages_test_case(name):
         tags = ["manual"],
     )
     _root_packages_test(
-        name = name + "_test",
+        name = name,
         target_under_test = name + "_javadoc",
     )
 
-def analysis_test_suite(name):
-    _deps_test_case(name = name + "_dep")
-    _group_test_case(name = name + "_group")
-    _links_test_case(name = name + "_links")
-    _root_packages_test_case(name = name + "_root_packages")
+def analysis_test_suite(name = "unused"):
+    _deps_test_case(name = "deps_test")
+    _group_test_case(name = "group_test")
+    _links_test_case(name = "links_test")
+    _root_packages_test_case(name = "root_packages_test")
 
     native.test_suite(
         name = name,
         tests = [
-            ":%s_dep_test" % name,
-            ":%s_group_test" % name,
-            ":%s_links_test" % name,
-            ":%s_root_packages_test" % name,
+            ":deps_test",
+            ":group_test",
+            ":links_test",
+            ":root_packages_test",
         ],
     )

--- a/tools/javadoc/tests.bzl
+++ b/tools/javadoc/tests.bzl
@@ -1,0 +1,109 @@
+# Copyright (C) 2022 The Google Bazel Common Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load(":javadoc.bzl", "javadoc_library")
+
+"""
+Unit and analysis tests for the javadoc package.
+"""
+
+# Verify handing of `attr.groups`.
+def _group_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    acts = analysistest.target_actions(env)
+    asserts.equals(env, 2, len(acts))
+    act = acts[0]  # javadoc action
+
+    idx = act.argv.index("-group")
+    asserts.equals(
+        env,
+        ["-group", "myheading", "build.bazel.pkg1:build.bazel.pkg2"],
+        act.argv[idx:idx + 3],
+    )
+
+    return analysistest.end(env)
+
+_group_test = analysistest.make(_group_test_impl)
+
+def _group_test_case(name):
+    javadoc_library(
+        name = name + "_javadoc",
+        srcs = ["dummy.java"],
+        groups = {"myheading": ["build.bazel.pkg1", "build.bazel.pkg2"]},
+        tags = ["manual"],
+    )
+    _group_test(
+        name = name + "_test",
+        target_under_test = name + "_javadoc",
+    )
+
+# Verify handling of `attr.root_packages`.
+def _root_packages_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    acts = analysistest.target_actions(env)
+    asserts.equals(env, 2, len(acts))
+    act = acts[0]  # javadoc action
+
+    idx = act.argv.index("bazel.build.foo")
+    asserts.equals(env, ["bazel.build.foo", "bazel.build.bar"], act.argv[idx:idx + 2])
+
+    idx = act.argv.index("-subpackages")
+    asserts.equals(
+        env,
+        ["-subpackages", "bazel.build.foo:bazel.build.bar"],
+        act.argv[idx:idx + 2],
+    )
+
+    # root_packages is a filter/allowlist which `.java` files contradict.
+    # (These should be accessible to `javadoc` via the dynamic `-sourcepath`
+    # arg.)
+    asserts.equals(
+        env,
+        [],
+        [
+            x
+            for x in act.argv
+            if x.endswith(".java")
+        ],
+        "Expecting only Java packages, not .java source files",
+    )
+
+    return analysistest.end(env)
+
+_root_packages_test = analysistest.make(_root_packages_test_impl)
+
+def _root_packages_test_case(name):
+    javadoc_library(
+        name = name + "_javadoc",
+        srcs = ["dummy.java"],
+        root_packages = ["bazel.build.foo", "bazel.build.bar"],
+        tags = ["manual"],
+    )
+    _root_packages_test(
+        name = name + "_test",
+        target_under_test = name + "_javadoc",
+    )
+
+def analysis_test_suite(name):
+    _group_test_case(name = name + "_group")
+    _root_packages_test_case(name = name + "_root_packages")
+
+    native.test_suite(
+        name = name,
+        tests = [
+            ":%s_group_test" % name,
+            ":%s_root_packages_test" % name,
+        ]
+    )


### PR DESCRIPTION
Instead of forwarding `ctx.files.srcs` to the `javadoc` command-line, we'll
take a detour through `ctx.actions.args` so that we handle (a) tree artifacts
and (b) very long argument lists.

Resolves https://github.com/google/bazel-common/issues/161.