### PR TITLE
Update deleted JavaInfo fields in javadoc.bzl

### DIFF
--- a/tools/javadoc/javadoc.bzl
+++ b/tools/javadoc/javadoc.bzl
@@ -23,7 +23,7 @@ def _javadoc_library(ctx):
     transitive_deps = []
     for dep in ctx.attr.deps:
         if JavaInfo in dep:
-            transitive_deps.append(dep[JavaInfo].transitive_deps)
+            transitive_deps.append(dep[JavaInfo].transitive_compile_time_jars)
 
     if ctx.attr._android_jar:
         transitive_deps.append(ctx.attr._android_jar.files)


### PR DESCRIPTION
The fields have been deprecated since 2021, and dropped in Bazel@HEAD

`transitive_deps` -> `transitive_compile_time_jars` 

`transitive_runtime_deps` -> `transitive_runtime_jars`

Fixes: https://github.com/google/flogger/issues/361